### PR TITLE
Fix: CSV files no longer created when 'Enable Scheduled CSV Export' i…

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1444,7 +1444,7 @@ class Plugin:
             csv_filepath = None
             should_create_csv = False
             if is_scheduled_run:
-                should_create_csv = settings.get("enable_scheduled_csv_export", True)
+                should_create_csv = settings.get("enable_scheduled_csv_export", False)
             else:
                 # For manual runs (Dry Run, Run Now), always create the CSV
                 should_create_csv = True


### PR DESCRIPTION
…s disabled

Changed the default fallback value in settings.get() from True to False on line 1447. This ensures consistency with the setting definition which has default: False, and prevents CSV files from being created during scheduled runs when the setting is disabled.