### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/PiratesIRC/Dispatcharr-Event-Channel-Managarr-Plugin/security/code-scanning/1](https://github.com/PiratesIRC/Dispatcharr-Event-Channel-Managarr-Plugin/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: define it at the workflow root (applies to all jobs unless overridden), with `contents: read`, which is sufficient for `actions/checkout` and the shown read/test tasks.

**File/region to change**
- `.github/workflows/ci.yml`
- Insert the permissions block between the `on:` triggers and `jobs:`.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
